### PR TITLE
eeprom for STMxC8/CB, spindle enable fix.

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -110,7 +110,7 @@
 // #define HOMING_CYCLE_2                         // OPTIONAL: Uncomment and add axes mask to enable
 
 // NOTE: The following are two examples to setup homing for 2-axis machines.
-// #define HOMING_CYCLE_0 ((1<<X_AXIS)|(1<<Y_AXIS))  // NOT COMPATIBLE WITH COREXY: Homes both X-Y in one cycle. 
+// #define HOMING_CYCLE_0 ((1<<X_AXIS)|(1<<Y_AXIS))  // NOT COMPATIBLE WITH COREXY: Homes both X-Y in one cycle.
 
 // #define HOMING_CYCLE_0 (1<<X_AXIS)  // COREXY COMPATIBLE: First home X
 // #define HOMING_CYCLE_1 (1<<Y_AXIS)  // COREXY COMPATIBLE: Then home Y
@@ -120,7 +120,7 @@
 // greater.
 #define N_HOMING_LOCATE_CYCLE 1 // Integer (1-128)
 
-// Enables single axis homing commands. $HX, $HY, and $HZ for X, Y, and Z-axis homing. The full homing 
+// Enables single axis homing commands. $HX, $HY, and $HZ for X, Y, and Z-axis homing. The full homing
 // cycle is still invoked by the $H command. This is disabled by default. It's here only to address
 // users that need to switch between a two-axis and three-axis machine. This is actually very rare.
 // If you have a two-axis machine, DON'T USE THIS. Instead, just alter the homing cycle for two-axes.
@@ -211,7 +211,7 @@
 // NOTE: If VARIABLE_SPINDLE is enabled(default), this option has no effect as the PWM output and
 // spindle enable are combined to one pin. If you need both this option and spindle speed PWM,
 // uncomment the config option USE_SPINDLE_DIR_AS_ENABLE_PIN below.
-// #define INVERT_SPINDLE_ENABLE_PIN // Default disabled. Uncomment to enable.
+//#define INVERT_SPINDLE_ENABLE_PIN // Default disabled. Uncomment to enable.
 
 // Inverts the selected coolant pin from low-disabled/high-enabled to low-enabled/high-disabled. Useful
 // for some pre-built electronic boards.
@@ -265,7 +265,7 @@
 
 // The status report change for Grbl v1.1 and after also removed the ability to disable/enable most data
 // fields from the report. This caused issues for GUI developers, who've had to manage several scenarios
-// and configurations. The increased efficiency of the new reporting style allows for all data fields to 
+// and configurations. The increased efficiency of the new reporting style allows for all data fields to
 // be sent without potential performance issues.
 // NOTE: The options below are here only provide a way to disable certain data fields if a unique
 // situation demands it, but be aware GUIs may depend on this data. If disabled, it may not be compatible.
@@ -367,16 +367,16 @@
 // preserve I/O pins. For certain setups, these may need to be separate pins. This configure option uses
 // the spindle direction pin(D13) as a separate spindle enable pin along with spindle speed PWM on pin D11.
 // NOTE: This configure option only works with VARIABLE_SPINDLE enabled and a 328p processor (Uno).
-// NOTE: Without a direction pin, M4 will not have a pin output to indicate a difference with M3. 
+// NOTE: Without a direction pin, M4 will not have a pin output to indicate a difference with M3.
 // NOTE: BEWARE! The Arduino bootloader toggles the D13 pin when it powers up. If you flash Grbl with
 // a programmer (you can use a spare Arduino as "Arduino as ISP". Search the web on how to wire this.),
 // this D13 LED toggling should go away. We haven't tested this though. Please report how it goes!
 // #define USE_SPINDLE_DIR_AS_ENABLE_PIN // Default disabled. Uncomment to enable.
 
 // Alters the behavior of the spindle enable pin with the USE_SPINDLE_DIR_AS_ENABLE_PIN option . By default,
-// Grbl will not disable the enable pin if spindle speed is zero and M3/4 is active, but still sets the PWM 
+// Grbl will not disable the enable pin if spindle speed is zero and M3/4 is active, but still sets the PWM
 // output to zero. This allows the users to know if the spindle is active and use it as an additional control
-// input. However, in some use cases, user may want the enable pin to disable with a zero spindle speed and 
+// input. However, in some use cases, user may want the enable pin to disable with a zero spindle speed and
 // re-enable when spindle speed is greater than zero. This option does that.
 // NOTE: Requires USE_SPINDLE_DIR_AS_ENABLE_PIN to be enabled.
 // #define SPINDLE_ENABLE_OFF_WITH_ZERO_SPEED // Default disabled. Uncomment to enable.
@@ -443,7 +443,7 @@
 // available RAM, like when re-compiling for a Mega2560. Or decrease if the Arduino begins to
 // crash due to the lack of available RAM or if the CPU is having trouble keeping up with planning
 // new incoming motions as they are executed.
-// #define BLOCK_BUFFER_SIZE 16 // Uncomment to override default in planner.h.
+#define BLOCK_BUFFER_SIZE 32 // Uncomment to override default in planner.h.
 
 // Governs the size of the intermediary step segment buffer between the step execution algorithm
 // and the planner blocks. Each segment is set of steps executed at a constant velocity over a
@@ -451,7 +451,7 @@
 // block velocity profile is traced exactly. The size of this buffer governs how much step
 // execution lead time there is for other Grbl processes have to compute and do their thing
 // before having to come back and refill this buffer, currently at ~50msec of step moves.
-// #define SEGMENT_BUFFER_SIZE 6 // Uncomment to override default in stepper.h.
+#define SEGMENT_BUFFER_SIZE 24 // Uncomment to override default in stepper.h.
 
 // Line buffer size from the serial input stream to be executed. Also, governs the size of
 // each of the startup blocks, as they are each stored as a string of this size. Make sure
@@ -476,12 +476,12 @@
 // #define RX_BUFFER_SIZE 128 // (1-254) Uncomment to override defaults in serial.h
 // #define TX_BUFFER_SIZE 100 // (1-254)
 
-// A simple software debouncing feature for hard limit switches. When enabled, the interrupt 
-// monitoring the hard limit switch pins will enable the Arduino's watchdog timer to re-check 
-// the limit pin state after a delay of about 32msec. This can help with CNC machines with 
-// problematic false triggering of their hard limit switches, but it WILL NOT fix issues with 
+// A simple software debouncing feature for hard limit switches. When enabled, the interrupt
+// monitoring the hard limit switch pins will enable the Arduino's watchdog timer to re-check
+// the limit pin state after a delay of about 32msec. This can help with CNC machines with
+// problematic false triggering of their hard limit switches, but it WILL NOT fix issues with
 // electrical interference on the signal cables from external sources. It's recommended to first
-// use shielded signal cables with their shielding connected to ground (old USB/computer cables 
+// use shielded signal cables with their shielding connected to ground (old USB/computer cables
 // work well and are cheap to find) and wire in a low-pass circuit into each limit pin.
 // #define ENABLE_SOFTWARE_DEBOUNCE // Default disabled. Uncomment to enable.
 
@@ -556,8 +556,8 @@
 #define FORCE_BUFFER_SYNC_DURING_WCO_CHANGE // Default enabled. Comment to disable.
 
 // By default, Grbl disables feed rate overrides for all G38.x probe cycle commands. Although this
-// may be different than some pro-class machine control, it's arguable that it should be this way. 
-// Most probe sensors produce different levels of error that is dependent on rate of speed. By 
+// may be different than some pro-class machine control, it's arguable that it should be this way.
+// Most probe sensors produce different levels of error that is dependent on rate of speed. By
 // keeping probing cycles to their programmed feed rates, the probe sensor should be a lot more
 // repeatable. If needed, you can disable this behavior by uncommenting the define below.
 // #define ALLOW_FEED_OVERRIDE_DURING_PROBE_CYCLES // Default disabled. Uncomment to enable.
@@ -585,11 +585,11 @@
 #define PARKING_PULLOUT_INCREMENT 5.0 // Spindle pull-out and plunge distance in mm. Incremental distance.
                                       // Must be positive value or equal to zero.
 
-// Enables a special set of M-code commands that enables and disables the parking motion. 
-// These are controlled by `M56`, `M56 P1`, or `M56 Px` to enable and `M56 P0` to disable. 
-// The command is modal and will be set after a planner sync. Since it is g-code, it is 
+// Enables a special set of M-code commands that enables and disables the parking motion.
+// These are controlled by `M56`, `M56 P1`, or `M56 Px` to enable and `M56 P0` to disable.
+// The command is modal and will be set after a planner sync. Since it is g-code, it is
 // executed in sync with g-code commands. It is not a real-time command.
-// NOTE: PARKING_ENABLE is required. By default, M56 is active upon initialization. Use 
+// NOTE: PARKING_ENABLE is required. By default, M56 is active upon initialization. Use
 // DEACTIVATE_PARKING_UPON_INIT to set M56 P0 as the power-up default.
 // #define ENABLE_PARKING_OVERRIDE_CONTROL   // Default disabled. Uncomment to enable
 // #define DEACTIVATE_PARKING_UPON_INIT // Default disabled. Uncomment to enable.
@@ -601,7 +601,7 @@
 #define DISABLE_LASER_DURING_HOLD // Default enabled. Comment to disable.
 
 // Enables a piecewise linear model of the spindle PWM/speed output. Requires a solution by the
-// 'fit_nonlinear_spindle.py' script in the /doc/script folder of the repo. See file comments 
+// 'fit_nonlinear_spindle.py' script in the /doc/script folder of the repo. See file comments
 // on how to gather spindle data and run the script to generate a solution.
 // #define ENABLE_PIECEWISE_LINEAR_SPINDLE  // Default disabled. Uncomment to enable.
 

--- a/grbl/spindle_control.c
+++ b/grbl/spindle_control.c
@@ -131,18 +131,20 @@ void spindle_stop()
 {
 #ifdef STM32
   #ifdef VARIABLE_SPINDLE
-//      TIM_CtrlPWMOutputs(TIM1, DISABLE);
-	    //Spindle_PWM_Stop();
-			//LL_TIM_DisableAllOutputs(TIM2);
-			Spindle_Disable();
+	Spindle_Disable();
+	#ifdef INVERT_SPINDLE_ENABLE_PIN
+	   SetSpindleEnablebit();
+	#else
+	   ResetSpindleEnablebit();
+	#endif
 
-      #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
+    #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
         #ifdef INVERT_SPINDLE_ENABLE_PIN
           SetSpindleEnablebit();
         #else
           ResetSpindleEnablebit();
         #endif
-      #endif
+     #endif
   #else
       #ifdef INVERT_SPINDLE_ENABLE_PIN
         SetSpindleEnablebit();
@@ -197,17 +199,23 @@ void spindle_stop()
     #else
       if (pwm_value == SPINDLE_PWM_OFF_VALUE)
       {
-        //TIM_CtrlPWMOutputs(TIM1, DISABLE);
-        //Spindle_PWM_Stop();
-      	//LL_TIM_DisableAllOutputs(TIM2);
       	Spindle_Disable();
+		#ifdef INVERT_SPINDLE_ENABLE_PIN
+		   SetSpindleEnablebit();
+		#else
+		   ResetSpindleEnablebit();
+		#endif
+
       }
       else
       {
-        //TIM_CtrlPWMOutputs(TIM1, ENABLE);
-        //Spindle_PWM_Start();
-        //LL_TIM_EnableAllOutputs(TIM2);
       	Spindle_Enable();
+		#ifdef INVERT_SPINDLE_ENABLE_PIN
+		   ResetSpindleEnablebit();
+		#else
+		   SetSpindleEnablebit();
+		#endif
+
       }
     #endif
 

--- a/grbl/stepper.c
+++ b/grbl/stepper.c
@@ -107,7 +107,11 @@ typedef struct {
   #endif
 
   uint8_t execute_step;     // Flags step execution for each interrupt.
-  uint8_t step_pulse_time;  // Step pulse reset time after step rise
+  #ifdef STM32
+	uint16_t step_pulse_time;  // Step pulse reset time after step rise - need more bits @ 72Mhz
+  #else
+  	uint8_t step_pulse_time;  // Step pulse reset time after step rise
+  #endif
   PIN_MASK step_outbits;         // The next stepping-bits to be output
   PIN_MASK dir_outbits;
   #ifdef ADAPTIVE_MULTI_AXIS_STEP_SMOOTHING
@@ -1199,5 +1203,3 @@ float st_get_realtime_rate()
   }
   return 0.0f;
 }
-
-

--- a/stm32/stm32eeprom.h
+++ b/stm32/stm32eeprom.h
@@ -186,8 +186,20 @@
 	#define ADDR_FLASH_PAGE_126   ((uint32_t)0x0801F800) /* Base @ of Page 126, 1 Kbytes */
 	#define ADDR_FLASH_PAGE_127   ((uint32_t)0x0801FC00) /* Base @ of Page 127, 1 Kbytes */
 
+#ifdef STM32F103C8_EEPROM
+	#define EEPROM_START_ADDRESS  ADDR_FLASH_PAGE_63		//-- use the last page of 64k
+
+#endif
+#ifdef STM32F103CB_EEPROM
 	#define EEPROM_START_ADDRESS  ADDR_FLASH_PAGE_127		//-- use the last page
-	extern void FLASH_PageErase(uint32_t PageAddress);	//-- this was NOT exported from stem32f1xx_hal_flash_ex.c for some reason
+
+#endif
+
+#ifndef EEPROM_START_ADDRESS
+#error "Must define either STM32F103CB_EEPROM or STM32F103C8_EEPROM for STM32F1"
+#endif 
+
+extern void FLASH_PageErase(uint32_t PageAddress);	//-- this was NOT exported from stem32f1xx_hal_flash_ex.c for some reason
 
 
 #endif
@@ -219,5 +231,3 @@
 
 
 #endif /* __STM32EEPROM_H */
-
-


### PR DESCRIPTION
Added a define for stm32f103c8 (64k spec) vs stm32f103cb (128k spec) - I've got several blue pill boards with 128k, some with 64k, all labeled as c8's.

Fixed the spindle enable.  With the defines configured to enable this, it is disallowed by the atmel 328 code.  Now assumes that spindle enable is used, and invert is allowed.